### PR TITLE
fix: Remove missing icon paths from manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,16 +21,5 @@
       "js": ["utils.js", "content.js"],
       "run_at": "document_idle"
     }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": ["assets/*"],
-      "matches": ["https://*.example-yamatan.jp/*"]
-    }
-  ],
-  "icons": {
-    "16": "assets/icon16.png",
-    "48": "assets/icon48.png",
-    "128": "assets/icon128.png"
-  }
+  ]
 }


### PR DESCRIPTION
This commit resolves an extension loading error by removing the `icons` and `web_accessible_resources` keys from `manifest.json`.

The manifest previously referenced icon files in an `assets/` directory that did not exist, causing Chrome to fail when loading the extension. This change removes the references, allowing the extension to load correctly with a default icon. A trailing comma was also removed to ensure valid JSON syntax.