### PR TITLE
feat: Add prerequisite checker to options page

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,82 @@
+// This is a placeholder for the scraper functions that will be defined in the next step.
+// I'm including them here to make the code runnable.
+const scrapeFunctions = {
+  checkProfile: () => {
+    const requiredInputs = Array.from(document.querySelectorAll('input[required], select[required]'));
+    const passportInput = document.querySelector('input[name="passport"]');
+    let isProfileComplete = true;
+    const missingFields = [];
+
+    requiredInputs.forEach(input => {
+      if (input === passportInput) return; // Skip passport as requested
+      if (!input.value) {
+        isProfileComplete = false;
+        missingFields.push(input.name);
+      }
+    });
+    return { isProfileComplete, missingFields };
+  },
+  checkCard: () => {
+    const cardInfo = document.querySelector('.LabelValueList_value__oFMk5');
+    return { hasCard: !!cardInfo && cardInfo.textContent.includes('****') };
+  }
+};
+
+
+/**
+ * Injects a scraper function into a new, temporary tab and returns the result.
+ * @param {string} url The URL of the page to open.
+ * @param {Function} scraperFn The function to inject and execute.
+ * @returns {Promise<any>} The result of the scraper function.
+ */
+async function scrapePage(url, scraperFn) {
+  let tab;
+  try {
+    tab = await chrome.tabs.create({ url, active: false });
+
+    // Wait for the tab to finish loading
+    await new Promise(resolve => {
+      const listener = (tabId, changeInfo) => {
+        if (tabId === tab.id && changeInfo.status === 'complete') {
+          chrome.tabs.onUpdated.removeListener(listener);
+          resolve();
+        }
+      };
+      chrome.tabs.onUpdated.addListener(listener);
+    });
+
+    const results = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: scraperFn,
+    });
+
+    // executeScript returns an array of results, we want the first one
+    return results[0].result;
+  } catch (error) {
+    console.error(`[Yamatan] Error scraping ${url}:`, error);
+    throw error; // Re-throw to be caught by the message listener
+  } finally {
+    if (tab) {
+      await chrome.tabs.remove(tab.id);
+    }
+  }
+}
+
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'checkPrerequisites') {
+    (async () => {
+      try {
+        const [profileResult, cardResult] = await Promise.all([
+          scrapePage('https://www.yamatan.net/user/mypage/profile', scrapeFunctions.checkProfile),
+          scrapePage('https://www.yamatan.net/user/mypage/card', scrapeFunctions.checkCard)
+        ]);
+
+        sendResponse({ success: true, profile: profileResult, card: cardResult });
+      } catch (error) {
+        sendResponse({ success: false, error: error.message });
+      }
+    })();
+    return true; // Indicates that the response is sent asynchronously
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -5,11 +5,15 @@
   "description": "山小屋「やまたん」の予約プロセスを自動化し、予約体験を劇的に向上させます。",
   "permissions": [
     "storage",
-    "scripting"
+    "scripting",
+    "tabs"
   ],
   "host_permissions": [
     "https://www.yamatan.net/*"
   ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_title": "設定",
     "default_popup": "options.html"

--- a/options.css
+++ b/options.css
@@ -191,3 +191,64 @@ footer {
 .button-danger:active, .button-secondary:active {
   transform: translateY(1px);
 }
+
+/* Styles for prerequisite checker */
+.prerequisites-check {
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-top: 1.5rem;
+}
+
+.prerequisites-check h3 {
+  margin-top: 0;
+  font-size: 1.1rem;
+  color: #34495e;
+  margin-bottom: 0.5rem;
+}
+
+.prerequisites-check p {
+  font-size: 0.9rem;
+  color: #6c757d;
+  margin: 0 0 1rem 0;
+}
+
+.results-area {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  display: none; /* Hidden by default */
+  background-color: #fff;
+  border: 1px solid #e0e0e0;
+}
+
+.results-area p {
+  margin: 0 0 0.5rem 0;
+  display: flex;
+  align-items: center;
+  color: #333;
+}
+
+.results-area p:last-child {
+  margin-bottom: 0;
+}
+
+.result-icon {
+  margin-right: 0.5rem;
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.result-ok {
+  color: #27ae60;
+}
+
+.result-error {
+  color: #e74c3c;
+}
+
+.result-checking {
+  color: #3498db;
+}

--- a/options.html
+++ b/options.html
@@ -58,6 +58,13 @@
         <p class="description">このチェックを外すと、最終確認ページの「同意して予約する」ボタンはクリックされません。デバッグやテストにご利用ください。</p>
       </div>
 
+      <div class="prerequisites-check">
+        <h3>事前情報チェック</h3>
+        <p>マイページに必要な情報（プロフィール・カード）が登録済みか確認します。</p>
+        <button id="check-prerequisites" class="button-secondary">登録状況をチェック</button>
+        <div id="prerequisites-results" class="results-area"></div>
+      </div>
+
       <div class="actions">
         <button id="save" class="button-primary">保存</button>
         <div id="status"></div>

--- a/options.js
+++ b/options.js
@@ -143,8 +143,55 @@ const clearSettings = () => {
 };
 
 
+/**
+ * Handles the prerequisite check button click.
+ */
+const handlePrerequisiteCheck = () => {
+  const checkButton = document.getElementById('check-prerequisites');
+  const resultsArea = document.getElementById('prerequisites-results');
+
+  // Disable button and show checking status
+  checkButton.disabled = true;
+  checkButton.textContent = 'チェック中...';
+  resultsArea.style.display = 'block';
+  resultsArea.innerHTML = `<p class="result-checking">マイページを確認しています...</p>`;
+
+  chrome.runtime.sendMessage({ action: 'checkPrerequisites' }, (response) => {
+    // Re-enable button
+    checkButton.disabled = false;
+    checkButton.textContent = '登録状況を再チェック';
+
+    if (response && response.success) {
+      const { profile, card } = response;
+      let resultsHTML = '';
+
+      // Profile check result
+      if (profile.isProfileComplete) {
+        resultsHTML += `<p><span class="result-icon result-ok">✔</span> プロフィール: 必須項目はすべて登録済みです。</p>`;
+      } else {
+        resultsHTML += `<p><span class="result-icon result-error">✖</span> プロフィール: 未入力の項目があります。(不足項目: ${profile.missingFields.join(', ') || '不明'})</p>`;
+      }
+
+      // Card check result
+      if (card.hasCard) {
+        resultsHTML += `<p><span class="result-icon result-ok">✔</span> クレジットカード: 登録済みです。</p>`;
+      } else {
+        resultsHTML += `<p><span class="result-icon result-error">✖</span> クレジットカード: 未登録です。</p>`;
+      }
+      resultsArea.innerHTML = resultsHTML;
+
+    } else {
+      // Handle errors, e.g., if the user is not logged in
+      const errorMessage = response?.error || '不明なエラーが発生しました。やまたんのサイトにログインしているか確認してください。';
+      resultsArea.innerHTML = `<p class="result-error">✖ チェックに失敗しました: ${errorMessage}</p>`;
+    }
+  });
+};
+
+
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.getElementById('save').addEventListener('click', saveOptions);
 document.getElementById('export-settings').addEventListener('click', exportSettings);
 document.getElementById('import-settings-input').addEventListener('change', importSettings);
 document.getElementById('clear-settings').addEventListener('click', clearSettings);
+document.getElementById('check-prerequisites').addEventListener('click', handlePrerequisiteCheck);


### PR DESCRIPTION
This feature adds a new section to the extension's settings page that allows the user to check if their required profile information and credit card details are registered on the yamatan.net website.

- Adds a "Check Registration Status" button and a results area to `options.html`.
- Introduces a `background.js` service worker to handle the scraping logic by opening the relevant pages in temporary, hidden tabs.
- Implements scraper functions to verify the completion of required profile fields and the existence of a saved credit card.
- Modifies `options.js` to communicate with the background script and display the results to the user.
- Adds necessary styles in `options.css` for the new UI elements.